### PR TITLE
Add support for more attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "google_pubsub_subscription" "subscription" {
   ack_deadline_seconds = 20
 
   enable_message_ordering = var.enable_message_ordering
-  filter = var.filter
+  filter                  = var.filter
 
   labels = var.labels
 

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "google_pubsub_subscription" "subscription" {
   ack_deadline_seconds = 20
 
   enable_message_ordering = var.enable_message_ordering
+  filter = var.filter
 
   labels = var.labels
 
@@ -28,7 +29,15 @@ resource "google_pubsub_subscription" "subscription" {
     for_each = var.disable_dlq ? [] : [1]
     content {
       dead_letter_topic     = "projects/${data.google_project.current.project_id}/topics/hedwig-${var.queue}-dlq"
-      max_delivery_attempts = 5
+      max_delivery_attempts = var.max_delivery_attempts
+    }
+  }
+
+  dynamic "retry_policy" {
+    for_each = var.retry_policy == null ? [] : [1]
+    content {
+      minimum_backoff = var.retry_policy["minimum_backoff"]
+      maximum_backoff = var.retry_policy["maximum_backoff"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,8 @@ resource "google_pubsub_subscription" "subscription" {
       maximum_backoff = var.retry_policy["maximum_backoff"]
     }
   }
+
+  retain_acked_messages = var.retain_acked_messages
 }
 
 data "google_iam_policy" "subscription_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,13 +29,13 @@ variable "disable_dlq" {
 variable "filter" {
   description = ") The subscription only delivers the messages that match the filter. Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription, you can't modify the filter."
   default     = ""
-  nullable = false
+  nullable    = false
 }
 
 variable "max_delivery_attempts" {
   description = "The maximum number of delivery attempts for any message. The value must be between 5 and 100. The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that client libraries may automatically extend ack_deadlines. This field will be honored on a best effort basis."
   default     = 5
-  nullable = false
+  nullable    = false
 }
 
 variable "retry_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,22 @@ variable "disable_dlq" {
   description = "Don't configure dlq policy. This is useful for firehose subscription using dataflow."
   default     = false
 }
+
+variable "filter" {
+  description = ") The subscription only delivers the messages that match the filter. Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription, you can't modify the filter."
+  default = ""
+}
+
+variable "max_delivery_attempts" {
+  description = "The maximum number of delivery attempts for any message. The value must be between 5 and 100. The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that client libraries may automatically extend ack_deadlines. This field will be honored on a best effort basis."
+  default = 5
+}
+
+variable "retry_policy" {
+  description = "A policy that specifies how Pub/Sub retries message delivery for this subscription. If not set, the default retry policy is applied. This generally implies that messages will be retried as soon as possible for healthy subscribers. RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message"
+  type = object({
+    minimum_backoff = number
+    maximum_backoff = number
+  })
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -28,12 +28,12 @@ variable "disable_dlq" {
 
 variable "filter" {
   description = ") The subscription only delivers the messages that match the filter. Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription, you can't modify the filter."
-  default = ""
+  default     = ""
 }
 
 variable "max_delivery_attempts" {
   description = "The maximum number of delivery attempts for any message. The value must be between 5 and 100. The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that client libraries may automatically extend ack_deadlines. This field will be honored on a best effort basis."
-  default = 5
+  default     = 5
 }
 
 variable "retry_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,18 +29,25 @@ variable "disable_dlq" {
 variable "filter" {
   description = ") The subscription only delivers the messages that match the filter. Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription, you can't modify the filter."
   default     = ""
+  nullable = false
 }
 
 variable "max_delivery_attempts" {
   description = "The maximum number of delivery attempts for any message. The value must be between 5 and 100. The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that client libraries may automatically extend ack_deadlines. This field will be honored on a best effort basis."
   default     = 5
+  nullable = false
 }
 
 variable "retry_policy" {
   description = "A policy that specifies how Pub/Sub retries message delivery for this subscription. If not set, the default retry policy is applied. This generally implies that messages will be retried as soon as possible for healthy subscribers. RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message"
   type = object({
-    minimum_backoff = number
-    maximum_backoff = number
+    minimum_backoff = string
+    maximum_backoff = string
   })
   default = null
+}
+
+variable "retain_acked_messages" {
+  description = "Indicates whether to retain acknowledged messages. If true, then messages are not expunged from the subscription's backlog, even if they are acknowledged, until they fall out of the messageRetentionDuration window."
+  default     = false
 }


### PR DESCRIPTION
- max delivery attempts should be customizable
- support for exponential retry policy, [message filtering](https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax) and acked message retention.